### PR TITLE
fix: use floating presentation mode for preferences dialog

### DIFF
--- a/resources/ui/preferences.ui
+++ b/resources/ui/preferences.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <object class="AdwDialog" id="dialog">
-    <property name="presentation-mode">bottom-sheet</property>
+    <property name="presentation-mode">floating</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="content-width">850</property>
     <property name="content-height">600</property>


### PR DESCRIPTION
The preferences dialog was using 'bottom-sheet' presentation mode which caused it to stretch to the bottom of the window and prevented resizing. Changed to 'floating' mode so it appears as a properly centered, resizable dialog. This annoyed me very much so i asked claude opus 4.6 for fix , so whole credits goes to it.

